### PR TITLE
LIBFCREPO-415. Updated to Modeshape 5.4 version of fcrepo.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.4</version>
   </parent>
 
   <groupId>edu.umd.lib</groupId>
@@ -14,7 +14,7 @@
   <packaging>war</packaging>
 
   <properties>
-    <fcrepo.version>4.7.4</fcrepo.version>
+    <fcrepo.version>4.7.4-umd-1.0</fcrepo.version>
     <logback.version>1.1.7</logback.version>
     <pgsql.version>9.4.1211</pgsql.version>
     <spring.version>4.3.3.RELEASE</spring.version>
@@ -63,12 +63,12 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-module-auth-webac</artifactId>
-      <version>${fcrepo.version}</version>
+      <version>4.7.4</version>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-audit</artifactId>
-      <version>${fcrepo.version}</version>
+      <version>4.7.4</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.ext</groupId>


### PR DESCRIPTION
Uses a custom local fork of fcrepo 4.7.4 to update the version of Modeshape to 5.4. Hold back the webac and audit module versions to 4.7.4, since we are still using the upstream version of them.

https://issues.umd.edu/browse/LIBFCREPO-415