### PR TITLE
LIBFCREPO-426. Remove the internal audit module.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>umd-fcrepo-webapp</artifactId>
   <name>Fedora Repository Deployable Web Application</name>
   <description>The Fedora web application</description>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <properties>
@@ -63,11 +63,6 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-module-auth-webac</artifactId>
-      <version>4.7.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.fcrepo</groupId>
-      <artifactId>fcrepo-audit</artifactId>
       <version>4.7.4</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bumped version to 2.0.0-SNAPSHOT. Removing the internal audit module qualifies for a major version change.

https://issues.umd.edu/browse/LIBFCREPO-426