### PR TITLE
LIBFCREPO-745. Use same fcrepo.version (4.7.5-umd-1.0) for WebAC as other fcrepo modules.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-module-auth-webac</artifactId>
-      <version>4.7.5</version>
+      <version>${fcrepo.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.ext</groupId>


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBFCREPO-745