### PR TITLE
LIBFCREPO-897. Implement JWT for access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ The [POM file](pom.xml) contains configuration suitable for running the applicat
 the [umd-fcrepo-docker](https://github.com/umd-lib/umd-fcrepo-docker) stack to provide the
 backing services.
 
-You must also provide environment variables for the LDAP bind password and the Postgres
-database password:
+You must also provide environment variables for the LDAP bind password, Postgres
+database password, and JWT secret:
 
 ```bash
 mvn clean package
 export FCREPO_DB_PASSWORD=...      # default in the umd-fcrepo-docker stack is "fcrepo"
 export UMD_LDAP_BIND_PASSWORD=...  # see the SSDR "Identities" document for this
+export UMD_JWT_SECRET=foobarbazquuzbazolazteschooglefooglebooglezorkgork # Can be anything, but must be sufficiently long.
 mvn cargo:run
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <jersey.version>2.24</jersey.version>
     <java.cas.client.version>3.6.0</java.cas.client.version>
     <warFileName>${project.artifactId}-${project.version}</warFileName>
+    <jwt.version>0.11.2</jwt.version>
   </properties>
 
   <distributionManagement>
@@ -131,6 +132,34 @@
         <artifactId>ldaptive</artifactId>
         <version>1.2.4</version>
     </dependency>
+
+
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>${jwt.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>${jwt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson if Gson is preferred -->
+      <version>${jwt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- Uncomment this next dependency if you are using JDK 10 or earlier and you also want to use
+         RSASSA-PSS (PS256, PS384, PS512) algorithms.  JDK 11 or later does not require it for those algorithms:
+    <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk15on</artifactId>
+        <version>1.60</version>
+        <scope>runtime</scope>
+    </dependency>
+    -->
   </dependencies>
 
   <build>
@@ -187,6 +216,7 @@
               <fcrepo.serverName>http://localhost:8080/</fcrepo.serverName>
               <fcrepo.activemq.url>tcp://localhost:61616</fcrepo.activemq.url>
               <umd.cas.serverURLPrefix>https://shib.idm.umd.edu/shibboleth-idp/profile/cas</umd.cas.serverURLPrefix>
+              <umd.jwt.secret>${env.UMD_JWT_SECRET}</umd.jwt.secret>
               <umd.ldap.url>ldap://directory.umd.edu</umd.ldap.url>
               <umd.ldap.baseDN>ou=people,dc=umd,dc=edu</umd.ldap.baseDN>
               <umd.ldap.bindDN>uid=libr-fedora,cn=auth,ou=ldap,dc=umd,dc=edu</umd.ldap.bindDN>

--- a/src/main/java/edu/umd/lib/fcrepo/GenerateTokenServlet.java
+++ b/src/main/java/edu/umd/lib/fcrepo/GenerateTokenServlet.java
@@ -1,0 +1,54 @@
+package edu.umd.lib.fcrepo;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.crypto.spec.SecretKeySpec;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+import static java.time.Instant.now;
+import static java.time.temporal.ChronoUnit.DAYS;
+
+public class GenerateTokenServlet extends HttpServlet {
+  private static final Logger logger = LoggerFactory.getLogger(GenerateTokenServlet.class);
+
+  private Key key;
+
+  @Override
+  public void init(ServletConfig config) throws ServletException {
+    super.init(config);
+    final String secret = config.getInitParameter("secret");
+    key = new SecretKeySpec(Base64.getDecoder().decode(secret), SignatureAlgorithm.HS256.getJcaName());
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    final String subject = req.getParameter("subject");
+    final String userName = req.getRemoteUser();
+    final Date expiry = Date.from(now().plus(365, DAYS));
+
+    logger.info("Creating token with subject: {}", subject);
+    logger.info("Issuer will be the requesting user: {}", userName);
+    logger.info("Expiration date: {}", expiry);
+
+    final String jws = Jwts.builder()
+        .setSubject(subject)
+        .setIssuer(userName)
+        .setExpiration(expiry)
+        .signWith(key)
+        .compact();
+
+    resp.setContentType("text/plain");
+    resp.getWriter().println(jws);
+  }
+}

--- a/src/main/java/edu/umd/lib/fcrepo/LdapRoleLookupService.java
+++ b/src/main/java/edu/umd/lib/fcrepo/LdapRoleLookupService.java
@@ -1,0 +1,171 @@
+package edu.umd.lib.fcrepo;
+
+import org.ldaptive.BindConnectionInitializer;
+import org.ldaptive.ConnectionConfig;
+import org.ldaptive.ConnectionFactory;
+import org.ldaptive.Credential;
+import org.ldaptive.DefaultConnectionFactory;
+import org.ldaptive.LdapAttribute;
+import org.ldaptive.LdapEntry;
+import org.ldaptive.LdapException;
+import org.ldaptive.SearchExecutor;
+import org.ldaptive.SearchResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+
+import javax.annotation.PostConstruct;
+import java.util.Collection;
+
+public class LdapRoleLookupService {
+  private static final Logger logger = LoggerFactory.getLogger(LdapRoleLookupService.class);
+
+  public static final String ADMIN_ROLE = "fedoraAdmin";
+
+  public static final String USER_ROLE = "fedoraUser";
+
+  private ConnectionFactory connectionFactory;
+
+  private String ldapURL;
+
+  private String bindDN;
+
+  private String bindPassword;
+
+  private String baseDN;
+
+  private String memberAttribute;
+
+  private String adminGroup;
+
+  private String userGroup;
+
+  private SearchExecutor searchExecutor;
+
+  public LdapRoleLookupService() {}
+
+  @PostConstruct
+  public void initialize() {
+    final ConnectionConfig connectionConfig = new ConnectionConfig(ldapURL);
+    connectionConfig.setUseStartTLS(true);
+    connectionConfig.setConnectionInitializer(new BindConnectionInitializer(bindDN, new Credential(bindPassword)));
+    connectionFactory = new DefaultConnectionFactory(connectionConfig);
+    searchExecutor = new SearchExecutor();
+    searchExecutor.setBaseDn(baseDN);
+
+    logger.info("Configured LDAP for user role lookup");
+    logger.info("LDAP URL: {} Base DN: {} Bind DN: {}", ldapURL, baseDN, bindDN);
+    logger.debug("Group {} => Role {}", adminGroup, ADMIN_ROLE);
+    logger.debug("Group {} => Role {}", userGroup, USER_ROLE);
+  }
+
+  /**
+   * Look up the given userName in the configured LDAP directory, and return the
+   * matching entry (if found).
+   *
+   * @param userName this should match a single uid in the directory
+   * @return matching entry or null
+   */
+  public LdapEntry getUserEntry(final String userName) {
+    try {
+      final String uidFilter = "uid=" + userName;
+      final SearchResult result = searchExecutor.search(connectionFactory, uidFilter, memberAttribute).getResult();
+      return result.getEntry();
+    } catch (LdapException e) {
+      logger.error("LDAP Exception: " + e);
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+  /**
+   * If the userEntry is a member of either the admin group or the user group,
+   * return the appropriate role string ("fedoraAdmin" or "fedoraUser", respectively).
+   * If the userEntry is null, or has neither membership relation, return null.
+   *
+   * @param userEntry LDAP entry for a user
+   * @return role name string: "fedoraAdmin", "fedoraUser", or null
+   */
+  public String getRole(final LdapEntry userEntry) {
+    if (userEntry == null) {
+      return null;
+    }
+
+    final LdapAttribute memberOfAttr = userEntry.getAttribute(memberAttribute);
+    final Collection<String> memberships = memberOfAttr.getStringValues();
+    if (memberships.contains(adminGroup)) {
+      return ADMIN_ROLE;
+    } else if (memberships.contains(userGroup)){
+      return USER_ROLE;
+    }
+    return null;
+  }
+
+  public String getRole(final String userName) {
+    return getRole(getUserEntry(userName));
+  }
+
+  public String getLdapURL() {
+    return ldapURL;
+  }
+
+  public void setLdapURL(String ldapURL) {
+    this.ldapURL = ldapURL;
+  }
+
+  public String getBindDN() {
+    return bindDN;
+  }
+
+  public void setBindDN(String bindDN) {
+    this.bindDN = bindDN;
+  }
+
+  public String getBindPassword() {
+    return bindPassword;
+  }
+
+  public void setBindPassword(String bindPassword) {
+    this.bindPassword = bindPassword;
+  }
+
+  public String getBaseDN() {
+    return baseDN;
+  }
+
+  public void setBaseDN(String baseDN) {
+    this.baseDN = baseDN;
+  }
+
+  public String getMemberAttribute() {
+    return memberAttribute;
+  }
+
+  public void setMemberAttribute(String memberAttribute) {
+    this.memberAttribute = memberAttribute;
+  }
+
+  public String getAdminGroup() {
+    return adminGroup;
+  }
+
+  public void setAdminGroup(String adminGroup) {
+    this.adminGroup = adminGroup;
+  }
+
+  public String getUserGroup() {
+    return userGroup;
+  }
+
+  public void setUserGroup(String userGroup) {
+    this.userGroup = userGroup;
+  }
+
+  public SearchExecutor getSearchExecutor() {
+    return searchExecutor;
+  }
+
+  public void setSearchExecutor(SearchExecutor searchExecutor) {
+    this.searchExecutor = searchExecutor;
+  }
+}

--- a/src/main/java/edu/umd/lib/fcrepo/ProvideUserPrincipalRequestWrapper.java
+++ b/src/main/java/edu/umd/lib/fcrepo/ProvideUserPrincipalRequestWrapper.java
@@ -1,0 +1,31 @@
+package edu.umd.lib.fcrepo;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.security.Principal;
+
+public class ProvideUserPrincipalRequestWrapper extends HttpServletRequestWrapper {
+  private final Principal userPrincipal;
+
+  /**
+   * Constructs a request object wrapping the given request.
+   *
+   * @param request request object
+   * @param userPrincipal user principal to return for getUserPrincipal()
+   * @throws IllegalArgumentException if the request is null
+   */
+  public ProvideUserPrincipalRequestWrapper(HttpServletRequest request, Principal userPrincipal) {
+    super(request);
+    this.userPrincipal = userPrincipal;
+  }
+
+  @Override
+  public String getRemoteUser() {
+    return userPrincipal.getName();
+  }
+
+  @Override
+  public Principal getUserPrincipal() {
+    return userPrincipal;
+  }
+}

--- a/src/main/java/edu/umd/lib/fcrepo/TokenAuthnzFilter.java
+++ b/src/main/java/edu/umd/lib/fcrepo/TokenAuthnzFilter.java
@@ -1,0 +1,98 @@
+package edu.umd.lib.fcrepo;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.jasig.cas.client.authentication.AttributePrincipalImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.crypto.spec.SecretKeySpec;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.Key;
+import java.security.Principal;
+import java.util.Base64;
+
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+
+public class TokenAuthnzFilter implements Filter {
+  private final Logger logger = LoggerFactory.getLogger(TokenAuthnzFilter.class);
+
+  private Key key;
+
+  private LdapRoleLookupService ldapRoleLookupService;
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    final String secret = filterConfig.getInitParameter("secret");
+    key = new SecretKeySpec(Base64.getDecoder().decode(secret), SignatureAlgorithm.HS256.getJcaName());
+
+    ldapRoleLookupService = WebApplicationContextUtils
+        .getRequiredWebApplicationContext(filterConfig.getServletContext())
+        .getBean(LdapRoleLookupService.class);
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    final HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+    final String authorizationHeader = httpRequest.getHeader("Authorization");
+    if (authorizationHeader != null && authorizationHeader.startsWith("Bearer")) {
+      String tokenString = authorizationHeader.substring(authorizationHeader.indexOf(" ") + 1);
+      logger.info("Bearer token: '{}'", tokenString);
+      try {
+        final Jws<Claims> jws = Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(tokenString);
+        logger.info("Successfully parsed JWT");
+        // we can safely trust the JWT
+        final Claims tokenBody = jws.getBody();
+        final String subject = tokenBody.getSubject();
+        logger.info("Token subject is {}", subject);
+        final String issuer = tokenBody.getIssuer();
+        logger.info("Token created by {}", issuer);
+        final String issuerRole = ldapRoleLookupService.getRole(issuer);
+        logger.info("Token creator has role {}", issuerRole);
+        logger.info("Token expires on {}", tokenBody.getExpiration());
+        final Principal userPrincipal = new AttributePrincipalImpl(subject);
+        final HttpServletRequest newRequest = requestWithUserAndRole(httpRequest, userPrincipal, issuerRole);
+        logger.debug("Request remote user: {}", newRequest.getRemoteUser());
+        logger.debug("Request user principal: {}", newRequest.getUserPrincipal());
+        logger.debug("Request user is admin? {}", newRequest.isUserInRole("fedoraAdmin"));
+        chain.doFilter(newRequest, response);
+      } catch (final JwtException e) {
+        // we *cannot* use the JWT as intended by its creator
+        logger.error("Unable to parse JWT: {}", e.getMessage());
+        final HttpServletResponse httpResponse = (HttpServletResponse) response;
+        // see https://tools.ietf.org/html/rfc6750#section-3.1
+        httpResponse.setHeader("WWW-Authenticate",
+            "Bearer error=\"invalid_token\", error_description=\"" + e.getMessage() + "\"");
+        httpResponse.sendError(SC_UNAUTHORIZED);
+      }
+    } else {
+      // no "Authorization: Bearer ..." header, go to next filter
+      chain.doFilter(request, response);
+    }
+  }
+
+  @Override
+  public void destroy() {
+
+  }
+
+  private HttpServletRequest requestWithUserAndRole(HttpServletRequest request, Principal userPrincipal, String role) {
+    return new ProvideRoleRequestWrapper(new ProvideUserPrincipalRequestWrapper(request, userPrincipal), role);
+  }
+}

--- a/src/main/resources/spring/configuration.xml
+++ b/src/main/resources/spring/configuration.xml
@@ -92,4 +92,15 @@
   <task:executor id="taskExecutor" pool-size="1" />
   <task:annotation-driven executor="taskExecutor" scheduler="taskScheduler" />
 
+  <!-- UMD AuthNZ config -->
+  <bean name="ldapLookupService" class="edu.umd.lib.fcrepo.LdapRoleLookupService">
+    <property name="ldapURL" value="${umd.ldap.url}"/>
+    <property name="bindDN" value="${umd.ldap.bindDN}"/>
+    <property name="bindPassword" value="${umd.ldap.bindPassword}"/>
+    <property name="baseDN" value="${umd.ldap.baseDN}"/>
+    <property name="memberAttribute" value="${umd.ldap.memberAttribute}"/>
+    <property name="adminGroup" value="${umd.ldap.group.fedoraAdmin}"/>
+    <property name="userGroup" value="${umd.ldap.group.fedoraUser}"/>
+  </bean>
+
 </beans>

--- a/src/main/webapp/WEB-INF/jsp/userinfo.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userinfo.jsp
@@ -13,8 +13,12 @@
 
     <p><a href="${repositoryRootPath}">Fedora REST API Endpoint</a></p>
 
+    <form action="/user/token" method="get">
+      <p><label>Subject: <input name="subject"/></label> <button>Create token</button></p>
+    </form>
+
     <form action="/user/logout" method="post">
-      <button>Log out</button>
+      <p><button>Log out</button></p>
     </form>
   </body>
 </html>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -144,6 +144,19 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>JWT Bearer Token AuthNZ Filter</filter-name>
+    <filter-class>edu.umd.lib.fcrepo.TokenAuthnzFilter</filter-class>
+    <init-param>
+      <param-name>secret</param-name>
+      <param-value>${umd.jwt.secret}</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>JWT Bearer Token AuthNZ Filter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>Fedora Roles Filter</filter-name>
     <filter-class>edu.umd.lib.fcrepo.FedoraRolesFilter</filter-class>
     <init-param>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -41,6 +41,15 @@
     <servlet-name>logout-servlet</servlet-name>
     <servlet-class>edu.umd.lib.fcrepo.LogoutServlet</servlet-class>
   </servlet>
+
+  <servlet>
+    <servlet-name>token-servlet</servlet-name>
+    <servlet-class>edu.umd.lib.fcrepo.GenerateTokenServlet</servlet-class>
+    <init-param>
+      <param-name>secret</param-name>
+      <param-value>${umd.jwt.secret}</param-value>
+    </init-param>
+  </servlet>
   
   <servlet-mapping>
     <servlet-name>jersey-servlet</servlet-name>
@@ -55,6 +64,11 @@
   <servlet-mapping>
     <servlet-name>logout-servlet</servlet-name>
     <url-pattern>/user/logout</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>
+    <servlet-name>token-servlet</servlet-name>
+    <url-pattern>/user/token</url-pattern>
   </servlet-mapping>
 
   <filter>


### PR DESCRIPTION
Added a servlet to generate JWTs:

- issuer is the logged in user
- user supplies the subject
- expiration is 365 days in the future

Added a JWT authnz filter.

- validates the JWT
- if valid, sets the user principal to the JWT subject and their role to the role of the issuer (i.e., the user that created this token)
- created a separate ldap role lookup service that is used by this filter and the FedoraRolesFilter

https://issues.umd.edu/browse/LIBFCREPO-897