### PR TITLE
LIBFCREPO-899. Get config from environment variables or system properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ database password, and JWT secret:
 
 ```bash
 mvn clean package
-export FCREPO_DB_PASSWORD=...      # default in the umd-fcrepo-docker stack is "fcrepo"
-export UMD_LDAP_BIND_PASSWORD=...  # see the SSDR "Identities" document for this
-export UMD_JWT_SECRET=foobarbazquuzbazolazteschooglefooglebooglezorkgork # Can be anything, but must be sufficiently long.
+export MODESHAPE_DB_PASSWORD=...      # default in the umd-fcrepo-docker stack is "fcrepo"
+export LDAP_BIND_PASSWORD=...         # see the SSDR "Identities" document for this
+export JWT_SECRET=...                 # Can be anything, but must be sufficiently long
 mvn cargo:run
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,22 +229,19 @@
               <extractDir>${project.build.directory}/extracts</extractDir>
             </zipUrlInstaller>
             <systemProperties>
-              <fcrepo.db.url>jdbc:postgresql://localhost:5432/fcrepo_modeshape5</fcrepo.db.url>
-              <fcrepo.db.driver>org.postgresql.Driver</fcrepo.db.driver>
-              <fcrepo.db.username>fcrepo</fcrepo.db.username>
-              <fcrepo.db.password>${env.FCREPO_DB_PASSWORD}</fcrepo.db.password>
-              <fcrepo.serverName>http://localhost:8080/</fcrepo.serverName>
-              <fcrepo.activemq.url>tcp://localhost:61616</fcrepo.activemq.url>
-              <umd.cas.serverURLPrefix>https://shib.idm.umd.edu/shibboleth-idp/profile/cas</umd.cas.serverURLPrefix>
-              <umd.jwt.secret>${env.UMD_JWT_SECRET}</umd.jwt.secret>
-              <umd.ldap.url>ldap://directory.umd.edu</umd.ldap.url>
-              <umd.ldap.baseDN>ou=people,dc=umd,dc=edu</umd.ldap.baseDN>
-              <umd.ldap.bindDN>uid=libr-fedora,cn=auth,ou=ldap,dc=umd,dc=edu</umd.ldap.bindDN>
-              <umd.ldap.bindPassword>${env.UMD_LDAP_BIND_PASSWORD}</umd.ldap.bindPassword>
-              <umd.ldap.memberAttribute>memberOf</umd.ldap.memberAttribute>
-              <umd.ldap.group.fedoraAdmin>cn=Application_Roles:Libraries:FCREPO:FCREPO-Administrator,ou=grouper,ou=group,dc=umd,dc=edu</umd.ldap.group.fedoraAdmin>
-              <umd.ldap.group.fedoraUser>cn=Application_Roles:Libraries:FCREPO:FCREPO-User,ou=grouper,ou=group,dc=umd,dc=edu</umd.ldap.group.fedoraUser>
-              <umd.fcrepo.ip-mapping.file>conf/test-ip-mapping.properties</umd.fcrepo.ip-mapping.file>
+              <MODESHAPE_DB_URL>jdbc:postgresql://localhost:5432/fcrepo_modeshape5</MODESHAPE_DB_URL>
+              <MODESHAPE_DB_DRIVER>org.postgresql.Driver</MODESHAPE_DB_DRIVER>
+              <MODESHAPE_DB_USERNAME>fcrepo</MODESHAPE_DB_USERNAME>
+              <FCREPO_BASE_URL>http://localhost:8080/</FCREPO_BASE_URL>
+              <ACTIVEMQ_URL>tcp://localhost:61616</ACTIVEMQ_URL>
+              <CAS_URL_PREFIX>https://shib.idm.umd.edu/shibboleth-idp/profile/cas</CAS_URL_PREFIX>
+              <LDAP_URL>ldap://directory.umd.edu</LDAP_URL>
+              <LDAP_BASE_DN>ou=people,dc=umd,dc=edu</LDAP_BASE_DN>
+              <LDAP_BIND_DN>uid=libr-fedora,cn=auth,ou=ldap,dc=umd,dc=edu</LDAP_BIND_DN>
+              <LDAP_MEMBER_ATTRIBUTE>memberOf</LDAP_MEMBER_ATTRIBUTE>
+              <LDAP_ADMIN_GROUP>cn=Application_Roles:Libraries:FCREPO:FCREPO-Administrator,ou=grouper,ou=group,dc=umd,dc=edu</LDAP_ADMIN_GROUP>
+              <LDAP_USER_GROUP>cn=Application_Roles:Libraries:FCREPO:FCREPO-User,ou=grouper,ou=group,dc=umd,dc=edu</LDAP_USER_GROUP>
+              <IP_MAPPING_FILE>conf/test-ip-mapping.properties</IP_MAPPING_FILE>
             </systemProperties>
           </container>
           <configuration>

--- a/src/main/java/edu/umd/lib/fcrepo/CasService.java
+++ b/src/main/java/edu/umd/lib/fcrepo/CasService.java
@@ -1,0 +1,19 @@
+package edu.umd.lib.fcrepo;
+
+public class CasService {
+  private String casUrlPrefix;
+
+  public CasService() {}
+
+  public String getCasLogoutUrl() {
+    return casUrlPrefix + "/logout";
+  }
+
+  public String getCasUrlPrefix() {
+    return casUrlPrefix;
+  }
+
+  public void setCasUrlPrefix(String casUrlPrefix) {
+    this.casUrlPrefix = casUrlPrefix;
+  }
+}

--- a/src/main/java/edu/umd/lib/fcrepo/GenerateTokenServlet.java
+++ b/src/main/java/edu/umd/lib/fcrepo/GenerateTokenServlet.java
@@ -1,11 +1,11 @@
 package edu.umd.lib.fcrepo;
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
-import javax.crypto.spec.SecretKeySpec;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -13,7 +13,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.Key;
-import java.util.Base64;
 import java.util.Date;
 
 import static java.time.Instant.now;
@@ -27,8 +26,9 @@ public class GenerateTokenServlet extends HttpServlet {
   @Override
   public void init(ServletConfig config) throws ServletException {
     super.init(config);
-    final String secret = config.getInitParameter("secret");
-    key = new SecretKeySpec(Base64.getDecoder().decode(secret), SignatureAlgorithm.HS256.getJcaName());
+    final WebApplicationContext context = WebApplicationContextUtils
+        .getRequiredWebApplicationContext(config.getServletContext());
+    key = context.getBean(SecretKeyService.class).getSecretKey();
   }
 
   @Override

--- a/src/main/java/edu/umd/lib/fcrepo/LogoutServlet.java
+++ b/src/main/java/edu/umd/lib/fcrepo/LogoutServlet.java
@@ -9,19 +9,24 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
 public class LogoutServlet extends HttpServlet {
-    private static final Logger log = LoggerFactory.getLogger(LogoutServlet.class);
+  private static final Logger log = LoggerFactory.getLogger(LogoutServlet.class);
 
-    @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-      final String remoteUser = request.getRemoteUser();
-      log.debug("Logging out: " + remoteUser);
-      
-      request.getSession().invalidate();
-      // Redirect to CAS logout to destroy CAS session
-      final String logoutURL = request.getServletContext().getInitParameter("casServerUrlPrefix") + "/logout";
-      log.info("Redirecting to CAS logout URL: {}", logoutURL);
-      response.sendRedirect(logoutURL);
-    }
+  @Override
+  protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    final String remoteUser = request.getRemoteUser();
+    log.debug("Logging out: " + remoteUser);
+
+    request.getSession().invalidate();
+    // Redirect to CAS logout to destroy CAS session
+    final WebApplicationContext context = WebApplicationContextUtils
+        .getRequiredWebApplicationContext(request.getServletContext());
+    final String logoutURL = context.getBean(CasService.class).getCasLogoutUrl();
+    log.info("Redirecting to CAS logout URL: {}", logoutURL);
+    response.sendRedirect(logoutURL);
+  }
 }
+

--- a/src/main/java/edu/umd/lib/fcrepo/SecretKeyService.java
+++ b/src/main/java/edu/umd/lib/fcrepo/SecretKeyService.java
@@ -1,0 +1,25 @@
+package edu.umd.lib.fcrepo;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Base64;
+
+public class SecretKeyService {
+  private String secret;
+
+  public SecretKeyService() {}
+
+  public String getSecret() {
+    return secret;
+  }
+
+  public void setSecret(String secret) {
+    this.secret = secret;
+  }
+
+  public Key getSecretKey() {
+    return new SecretKeySpec(Base64.getDecoder().decode(secret), SignatureAlgorithm.HS256.getJcaName());
+  }
+}

--- a/src/main/java/edu/umd/lib/fcrepo/TokenAuthnzFilter.java
+++ b/src/main/java/edu/umd/lib/fcrepo/TokenAuthnzFilter.java
@@ -4,13 +4,12 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import org.jasig.cas.client.authentication.AttributePrincipalImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
-import javax.crypto.spec.SecretKeySpec;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -22,7 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.Key;
 import java.security.Principal;
-import java.util.Base64;
 
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
@@ -35,12 +33,10 @@ public class TokenAuthnzFilter implements Filter {
 
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
-    final String secret = filterConfig.getInitParameter("secret");
-    key = new SecretKeySpec(Base64.getDecoder().decode(secret), SignatureAlgorithm.HS256.getJcaName());
-
-    ldapRoleLookupService = WebApplicationContextUtils
-        .getRequiredWebApplicationContext(filterConfig.getServletContext())
-        .getBean(LdapRoleLookupService.class);
+    final WebApplicationContext context = WebApplicationContextUtils
+        .getRequiredWebApplicationContext(filterConfig.getServletContext());
+    key = context.getBean(SecretKeyService.class).getSecretKey();
+    ldapRoleLookupService = context.getBean(LdapRoleLookupService.class);
   }
 
   @Override

--- a/src/main/resources/repository.json
+++ b/src/main/resources/repository.json
@@ -10,10 +10,10 @@
     "storage" : {
         "persistence": {
             "type" : "db",
-            "connectionUrl": "${fcrepo.db.url}",
-            "driver" : "${fcrepo.db.driver}",
-            "username" : "${fcrepo.db.username}",
-            "password" : "${fcrepo.db.password}"
+            "connectionUrl": "${MODESHAPE_DB_URL}",
+            "driver" : "${MODESHAPE_DB_DRIVER}",
+            "username" : "${MODESHAPE_DB_USERNAME}",
+            "password" : "${MODESHAPE_DB_PASSWORD}"
         },
         "binaryStorage" : {
             "type" : "file",

--- a/src/main/resources/spring/configuration.xml
+++ b/src/main/resources/spring/configuration.xml
@@ -68,7 +68,7 @@
   </bean>
 
   <bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
-    <property name="brokerURL" value="${fcrepo.activemq.url:tcp://localhost:61616}"/>
+    <property name="brokerURL" value="${ACTIVEMQ_URL}"/>
   </bean>
 
   <!-- translates events into JMS header-only format-->
@@ -94,13 +94,37 @@
 
   <!-- UMD AuthNZ config -->
   <bean name="ldapLookupService" class="edu.umd.lib.fcrepo.LdapRoleLookupService">
-    <property name="ldapURL" value="${umd.ldap.url}"/>
-    <property name="bindDN" value="${umd.ldap.bindDN}"/>
-    <property name="bindPassword" value="${umd.ldap.bindPassword}"/>
-    <property name="baseDN" value="${umd.ldap.baseDN}"/>
-    <property name="memberAttribute" value="${umd.ldap.memberAttribute}"/>
-    <property name="adminGroup" value="${umd.ldap.group.fedoraAdmin}"/>
-    <property name="userGroup" value="${umd.ldap.group.fedoraUser}"/>
+    <property name="ldapURL" value="${LDAP_URL}"/>
+    <property name="bindDN" value="${LDAP_BIND_DN}"/>
+    <property name="bindPassword" value="${LDAP_BIND_PASSWORD}"/>
+    <property name="baseDN" value="${LDAP_BASE_DN}"/>
+    <property name="memberAttribute" value="${LDAP_MEMBER_ATTRIBUTE}"/>
+    <property name="adminGroup" value="${LDAP_ADMIN_GROUP}"/>
+    <property name="userGroup" value="${LDAP_USER_GROUP}"/>
   </bean>
 
+  <bean name="secretKeyService" class="edu.umd.lib.fcrepo.SecretKeyService">
+    <property name="secret" value="${JWT_SECRET}"/>
+  </bean>
+
+  <bean name="casService" class="edu.umd.lib.fcrepo.CasService">
+    <property name="casUrlPrefix" value="${CAS_URL_PREFIX}"/>
+  </bean>
+
+  <bean name="casAuthenticationFilter" class="org.jasig.cas.client.authentication.AuthenticationFilter">
+    <property name="serverName" value="${FCREPO_BASE_URL}" />
+    <property name="casServerLoginUrl" value="${CAS_URL_PREFIX}/login"/>
+  </bean>
+  <bean name="casValidationFilter" class="org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter">
+    <property name="serverName" value="${FCREPO_BASE_URL}"/>
+    <property name="ticketValidator">
+      <bean class="org.jasig.cas.client.validation.Cas20ServiceTicketValidator">
+        <constructor-arg index="0" value="${CAS_URL_PREFIX}" />
+      </bean>
+    </property>
+  </bean>
+  <bean name="ipMapperFilter" class="edu.umd.lib.fcrepo.IpMapperFilter">
+    <property name="headerName" value="X-Auth-IP-Mapper"/>
+    <property name="mappingFile" value="${IP_MAPPING_FILE}"/>
+  </bean>
 </beans>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -10,10 +10,6 @@
     <param-name>contextConfigLocation</param-name>
     <param-value>WEB-INF/classes/spring/repository.xml</param-value>
   </context-param>
-  <context-param>
-    <param-name>casServerUrlPrefix</param-name>
-    <param-value>${umd.cas.serverURLPrefix}</param-value>
-  </context-param>
 
   <listener>
     <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
@@ -45,10 +41,6 @@
   <servlet>
     <servlet-name>token-servlet</servlet-name>
     <servlet-class>edu.umd.lib.fcrepo.GenerateTokenServlet</servlet-class>
-    <init-param>
-      <param-name>secret</param-name>
-      <param-value>${umd.jwt.secret}</param-value>
-    </init-param>
   </servlet>
   
   <servlet-mapping>
@@ -95,20 +87,13 @@
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 
+  <!-- using the Spring DelegatingFilterProxy allows us to configure the filters using environment variables -->
   <filter>
     <filter-name>CAS Authentication Filter</filter-name>
-    <filter-class>org.jasig.cas.client.authentication.AuthenticationFilter</filter-class>
+    <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
     <init-param>
-      <param-name>casServerLoginUrl</param-name>
-      <param-value>${umd.cas.serverURLPrefix}/login</param-value>
-    </init-param>
-    <init-param>
-      <param-name>serverName</param-name>
-      <param-value>${fcrepo.serverName}</param-value>
-    </init-param>
-    <init-param>
-      <param-name>ignorePattern</param-name>
-      <param-value>logout</param-value>
+      <param-name>targetBeanName</param-name>
+      <param-value>casAuthenticationFilter</param-value>
     </init-param>
   </filter>
   <!-- only redirect to login for unauthenticated users in the /user URL space -->
@@ -119,14 +104,10 @@
 
   <filter>
     <filter-name>CAS Validation Filter</filter-name>
-    <filter-class>org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter</filter-class>
+    <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
     <init-param>
-      <param-name>casServerUrlPrefix</param-name>
-      <param-value>${umd.cas.serverURLPrefix}</param-value>
-    </init-param>
-    <init-param>
-      <param-name>serverName</param-name>
-      <param-value>${fcrepo.serverName}</param-value>
+      <param-name>targetBeanName</param-name>
+      <param-value>casValidationFilter</param-value>
     </init-param>
   </filter>
   <filter-mapping>
@@ -146,10 +127,6 @@
   <filter>
     <filter-name>JWT Bearer Token AuthNZ Filter</filter-name>
     <filter-class>edu.umd.lib.fcrepo.TokenAuthnzFilter</filter-class>
-    <init-param>
-      <param-name>secret</param-name>
-      <param-value>${umd.jwt.secret}</param-value>
-    </init-param>
   </filter>
   <filter-mapping>
     <filter-name>JWT Bearer Token AuthNZ Filter</filter-name>
@@ -159,36 +136,7 @@
   <filter>
     <filter-name>Fedora Roles Filter</filter-name>
     <filter-class>edu.umd.lib.fcrepo.FedoraRolesFilter</filter-class>
-    <init-param>
-      <param-name>ldapURL</param-name>
-      <param-value>${umd.ldap.url}</param-value>
-    </init-param>
-    <init-param>
-      <param-name>baseDN</param-name>
-      <param-value>${umd.ldap.baseDN}</param-value>
-    </init-param>
-    <init-param>
-      <param-name>bindDN</param-name>
-      <param-value>${umd.ldap.bindDN}</param-value>
-    </init-param>
-    <init-param>
-      <param-name>bindPassword</param-name>
-      <param-value>${umd.ldap.bindPassword}</param-value>
-    </init-param>
-    <init-param>
-      <param-name>memberAttribute</param-name>
-      <param-value>${umd.ldap.memberAttribute}</param-value>
-    </init-param>
-    <init-param>
-      <param-name>adminGroup</param-name>
-      <param-value>${umd.ldap.group.fedoraAdmin}</param-value>
-    </init-param>
-    <init-param>
-      <param-name>userGroup</param-name>
-      <param-value>${umd.ldap.group.fedoraUser}</param-value>
-    </init-param>
   </filter>
-
   <!-- look up user role on any request to the /user or /rest URL spaces -->
   <!-- we can omit the /static and / (root) spaces, since those are not access-restricted -->
   <filter-mapping>
@@ -199,14 +147,10 @@
   
   <filter>
     <filter-name>Fedora IP Mapper Filter</filter-name>
-    <filter-class>edu.umd.lib.fcrepo.IpMapperFilter</filter-class>
+    <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
     <init-param>
-      <param-name>headerName</param-name>
-      <param-value>X-Auth-IP-Mapper</param-value>
-    </init-param>
-    <init-param>
-      <param-name>mappingFile</param-name>
-      <param-value>${umd.fcrepo.ip-mapping.file}</param-value>
+      <param-name>targetBeanName</param-name>
+      <param-value>ipMapperFilter</param-value>
     </init-param>
   </filter>
   <!-- Map user's IP address to allowed categories on any request to the /user or /rest URL spaces -->


### PR DESCRIPTION
Wrap some of the filters in spring delegating filter proxies to allow configuration using spring beans (with environment variable placeholder substitution) in configuration.xml instead of init-params web.xml. This actually means we can supply configuration values either as environment variables or system properties.

https://issues.umd.edu/browse/LIBFCREPO-899