### PR TITLE
LIBFCREPO-1016. Default the JVM heap size to 2048 MB (2 GB) in the Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ FROM tomcat:7.0.106-jdk8-openjdk-buster@sha256:7389e901db3b2f9bb0268ce4cbd2ec2e1
 
 # default context path is the root, making the full URL e.g. http://localhost:8080/
 ENV CONTEXT_PATH=""
+# default heap size is 2 GB
+ENV TOMCAT_HEAP=2048m
+
 RUN mkdir -p /opt/umd-fcrepo-webapp
 COPY --from=compile /opt/umd-fcrepo-webapp/target/umd-fcrepo-webapp.war /opt/umd-fcrepo-webapp/
 COPY setenv.sh /usr/local/tomcat/bin/

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,1 +1,11 @@
-export CATALINA_OPTS="-Dfcrepo.home=/var/umd-fcrepo-webapp -Dfcrepo.context.path=${CONTEXT_PATH}"
+export CATALINA_OPTS="-XX:+UseConcMarkSweepGC \
+  -XX:+CMSClassUnloadingEnabled \
+  -XX:ConcGCThreads=5 \
+  -XX:MaxGCPauseMillis=200 \
+  -XX:ParallelGCThreads=20 \
+  -XX:MaxMetaspaceSize=512M \
+  -Xms${TOMCAT_HEAP} \
+  -Xmx${TOMCAT_HEAP} \
+  -Dfile.encoding=UTF-8 \
+  -Dfcrepo.home=/var/umd-fcrepo-webapp \
+  -Dfcrepo.context.path=${CONTEXT_PATH}"


### PR DESCRIPTION
Added Java configuration options to the setenv.sh. Set the default TOMCAT_HEAP in the Dockerfile to "2048m"; can be overridden at deploy time in Docker or Kubernetes.

https://issues.umd.edu/browse/LIBFCREPO-1016