### PR TITLE
LIBFCREPO-1001. Implement a "store-and-forward" message broker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,5 @@ COPY setenv.sh /usr/local/tomcat/bin/
 COPY server.xml /usr/local/tomcat/conf/
 
 VOLUME /var/umd-fcrepo-webapp
+# for the store-and-forward broker
+VOLUME /var/activemq

--- a/setenv.sh
+++ b/setenv.sh
@@ -8,4 +8,5 @@ export CATALINA_OPTS="-XX:+UseConcMarkSweepGC \
   -Xmx${TOMCAT_HEAP} \
   -Dfile.encoding=UTF-8 \
   -Dfcrepo.home=/var/umd-fcrepo-webapp \
+  -Dfcrepo.activemq.directory=/var/activemq \
   -Dfcrepo.context.path=${CONTEXT_PATH}"

--- a/src/main/resources/activemq.xml
+++ b/src/main/resources/activemq.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+  <context:property-placeholder/>
+
+  <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost">
+    <!-- set up a "store-and-forward" connection to the external ActiveMQ instance -->
+    <networkConnectors>
+      <networkConnector uri="static:(${ACTIVEMQ_URL})" staticBridge="true">
+        <staticallyIncludedDestinations>
+          <queue physicalName="fedora"/>
+        </staticallyIncludedDestinations>
+      </networkConnector>
+    </networkConnectors>
+
+    <!--
+        For better performances use VM cursor and small memory limit.
+        For more information, see:
+
+        http://activemq.apache.org/message-cursors.html
+
+        Also, if your producer is "hanging", it's probably due to producer flow control.
+        For more information, see:
+        http://activemq.apache.org/producer-flow-control.html
+    -->
+    <destinationPolicy>
+      <policyMap>
+        <policyEntries>
+          <policyEntry topic=">" producerFlowControl="true">
+            <!--
+                The constantPendingMessageLimitStrategy is used to prevent
+                slow topic consumers to block producers and affect other consumers
+                by limiting the number of messages that are retained
+                For more information, see: http://activemq.apache.org/slow-consumer-handling.html
+            -->
+            <pendingMessageLimitStrategy>
+              <constantPendingMessageLimitStrategy limit="1000"/>
+            </pendingMessageLimitStrategy>
+          </policyEntry>
+          <policyEntry queue=">" producerFlowControl="true" memoryLimit="1mb">
+            <!--
+                Use VM cursor for better latency
+                For more information, see: http://activemq.apache.org/message-cursors.html
+            -->
+            <pendingQueuePolicy>
+              <vmQueueCursor/>
+            </pendingQueuePolicy>
+          </policyEntry>
+        </policyEntries>
+      </policyMap>
+    </destinationPolicy>
+
+    <!--
+        The managementContext is used to configure how ActiveMQ is exposed in
+        JMX. By default, ActiveMQ uses the MBean server that is started by
+        the JVM. For more information, see: http://activemq.apache.org/jmx.html
+    -->
+    <managementContext>
+      <managementContext createConnector="false"/>
+    </managementContext>
+
+    <!--
+        Configure message persistence for the broker. The default persistence
+        mechanism is the KahaDB store (identified by the kahaDB tag).
+        For more information, see: http://activemq.apache.org/persistence.html
+    -->
+    <persistenceAdapter>
+      <kahaDB directory="${fcrepo.activemq.directory:ActiveMQ/kahadb}"/>
+    </persistenceAdapter>
+
+    <!--
+        The systemUsage controls the maximum amount of space the broker will
+        use before slowing down producers. For more information, see:
+        http://activemq.apache.org/producer-flow-control.html
+    -->
+    <systemUsage>
+      <systemUsage>
+        <memoryUsage>
+          <memoryUsage limit="20 mb"/>
+        </memoryUsage>
+        <storeUsage>
+          <storeUsage limit="1 gb"/>
+        </storeUsage>
+        <tempUsage>
+          <tempUsage limit="100 mb"/>
+        </tempUsage>
+      </systemUsage>
+    </systemUsage>
+
+    <!--
+        The transport connectors expose ActiveMQ over a given protocol to
+        clients and other brokers. For more information, see: http://activemq.apache.org/configuring-transports.html
+    -->
+    <transportConnectors>
+      <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
+      <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"/>
+    </transportConnectors>
+
+    <!-- destroy the spring context on shutdown to stop jetty -->
+    <shutdownHooks>
+      <bean xmlns="http://www.springframework.org/schema/beans" class="org.apache.activemq.hooks.SpringContextHook"/>
+    </shutdownHooks>
+  </broker>
+</beans>

--- a/src/main/resources/spring/configuration.xml
+++ b/src/main/resources/spring/configuration.xml
@@ -67,8 +67,14 @@
     <constructor-arg value="fedora"/>
   </bean>
 
-  <bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
-    <property name="brokerURL" value="${ACTIVEMQ_URL}"/>
+  <!-- configure an internal "buffering" broker that does a store-and-forward to the external AMQ -->
+  <bean name="jmsBroker" class="org.apache.activemq.xbean.BrokerFactoryBean">
+    <property name="config" value="classpath:/activemq.xml"/>
+    <property name="start" value="true"/>
+  </bean>
+
+  <bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory" depends-on="jmsBroker">
+    <property name="brokerURL" value="vm://localhost:61616?create=false"/>
   </bean>
 
   <!-- translates events into JMS header-only format-->


### PR DESCRIPTION
Implemented as an embedded ActiveMQ instance, listening on localhost:61616 for OpenWire connections. Configured as a static bridge of the "fedora" queue to the external message broker at the location given in ACTIVEMQ_URL. Added a /var/activemq volume to the Docker image for use as the persistent store for the queue.

https://issues.umd.edu/browse/LIBFCREPO-1001.