### PR TITLE
LIBFCREPO-1091. Configure the IP mapper header name via environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ properties, to run the application:
 |`CAS_URL_PREFIX`              |✓|https://shib.idm.umd.edu/shibboleth-idp/profile/cas|
 |`FCREPO_BASE_URL`             |✓|http://localhost:8080/|
 |`IP_MAPPING_FILE`             |✓|conf/test-ip-mapping.properties|
+|`IP_MAPPING_HEADER_NAME`      |✓|X-Auth-IP-Mapping|
 |`CREDENTIALS_FILE`            |✓|conf/basic-auth.properties|
 |`JWT_SECRET`                  | ||
 |`LDAP_URL`                    |✓|ldap://directory.umd.edu|

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,7 @@
               <LDAP_ADMIN_GROUP>cn=Application_Roles:Libraries:FCREPO:FCREPO-Administrator,ou=grouper,ou=group,dc=umd,dc=edu</LDAP_ADMIN_GROUP>
               <LDAP_USER_GROUP>cn=Application_Roles:Libraries:FCREPO:FCREPO-User,ou=grouper,ou=group,dc=umd,dc=edu</LDAP_USER_GROUP>
               <IP_MAPPING_FILE>conf/test-ip-mapping.properties</IP_MAPPING_FILE>
+              <IP_MAPPING_HEADER_NAME>X-Auth-IP-Mapping</IP_MAPPING_HEADER_NAME>
               <CREDENTIALS_FILE>conf/basic-auth.properties</CREDENTIALS_FILE>
             </systemProperties>
           </container>

--- a/src/main/resources/spring/configuration.xml
+++ b/src/main/resources/spring/configuration.xml
@@ -25,7 +25,7 @@
 
   <!-- Optional PrincipalProvider that will inspect a request header for user role values -->
   <bean name="headerProvider" class="org.fcrepo.auth.common.HttpHeaderPrincipalProvider">
-    <property name="headerName" value="X-UMDLibDelegatePrincipal"/>
+    <property name="headerName" value="${IP_MAPPING_HEADER_NAME}"/>
     <property name="separator" value=","/>
   </bean>
 
@@ -133,7 +133,7 @@
     <property name="credentialsFile" value="${CREDENTIALS_FILE}"/>
   </bean>
   <bean name="ipMapperFilter" class="edu.umd.lib.fcrepo.IpMapperFilter">
-    <property name="headerName" value="X-Auth-IP-Mapper"/>
+    <property name="headerName" value="${IP_MAPPING_HEADER_NAME}"/>
     <property name="mappingFile" value="${IP_MAPPING_FILE}"/>
   </bean>
 </beans>


### PR DESCRIPTION
Default (in the cargo:run profile of the POM file) is "X-Auth-IP-Mapping".

https://issues.umd.edu/browse/LIBFCREPO-1091