### PR TITLE
LIBFCREPO-1104. Update the base tomcat and maven docker images to ones that supports arm64 builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # docker build -t docker.lib.umd.edu/fcrepo-webapp:<VERSION> -f Dockerfile .
 #
 # where <VERSION> is the Docker image version to create.
-FROM maven:3.6.3-jdk-8-slim AS compile
+FROM maven:3.8.6-eclipse-temurin-11 AS compile
 
 ENV SOURCE_DIR /opt/umd-fcrepo-webapp
 COPY src $SOURCE_DIR/src
@@ -13,8 +13,7 @@ COPY pom.xml $SOURCE_DIR
 WORKDIR $SOURCE_DIR
 RUN mvn package -DwarFileName=umd-fcrepo-webapp
 
-# Note: Specifying SHA256 hash (for the "linux/amd64" architecture) to ensure Docker base image consistency
-FROM tomcat:7.0.109-jdk8-openjdk-slim-buster@sha256:429a25e0870545b4c9209fc7d048f1cd36a588f47b5088f8e130e49e7214353d
+FROM tomcat:8.5.83-jdk8-temurin-jammy
 
 # default context path is the root, making the full URL e.g. http://localhost:8080/
 ENV CONTEXT_PATH=""

--- a/server.xml
+++ b/server.xml
@@ -26,8 +26,6 @@
   -->
   <!--APR library loader. Documentation at /docs/apr.html -->
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
-  <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
-  <Listener className="org.apache.catalina.core.JasperListener" />
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />


### PR DESCRIPTION
Uses:
* maven:3.8.6-eclipse-temurin-11 for the build stage
* tomcat:8.5.83-jdk8-temurin-jammy for the docker image

Removed JasperListener from Tomcat server.xml config, since the JasperListener class was removed in Tomcat 8.5.

https://issues.umd.edu/browse/LIBFCREPO-1104