### PR TITLE
LIBFCREPO-1143. Startup time improvements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV TOMCAT_HEAP=2048m
 RUN mkdir -p /opt/umd-fcrepo-webapp
 COPY --from=compile /opt/umd-fcrepo-webapp/target/umd-fcrepo-webapp.war /opt/umd-fcrepo-webapp/
 COPY setenv.sh /usr/local/tomcat/bin/
-COPY server.xml /usr/local/tomcat/conf/
+COPY server.xml catalina.properties /usr/local/tomcat/conf/
 
 VOLUME /var/umd-fcrepo-webapp
 # for the store-and-forward broker

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # docker build -t docker.lib.umd.edu/fcrepo-webapp:<VERSION> -f Dockerfile .
 #
 # where <VERSION> is the Docker image version to create.
-FROM maven:3.8.6-eclipse-temurin-11 AS compile
+FROM maven:3.8.6-eclipse-temurin-8 AS compile
 
 ENV SOURCE_DIR /opt/umd-fcrepo-webapp
 COPY src $SOURCE_DIR/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV TOMCAT_HEAP=2048m
 RUN mkdir -p /opt/umd-fcrepo-webapp
 COPY --from=compile /opt/umd-fcrepo-webapp/target/umd-fcrepo-webapp.war /opt/umd-fcrepo-webapp/
 COPY setenv.sh /usr/local/tomcat/bin/
-COPY server.xml catalina.properties /usr/local/tomcat/conf/
+COPY server.xml catalina.properties logging.properties /usr/local/tomcat/conf/
 
 VOLUME /var/umd-fcrepo-webapp
 # for the store-and-forward broker

--- a/catalina.properties
+++ b/catalina.properties
@@ -1,0 +1,349 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageAccess unless the
+# corresponding RuntimePermission ("accessClassInPackage."+package) has
+# been granted.
+package.access=sun.,org.apache.catalina.,org.apache.coyote.,org.apache.jasper.,org.apache.tomcat.
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageDefinition unless the
+# corresponding RuntimePermission ("defineClassInPackage."+package) has
+# been granted.
+#
+# by default, no packages are restricted for definition, and none of
+# the class loaders supplied with the JDK call checkPackageDefinition.
+#
+package.definition=sun.,java.,org.apache.catalina.,org.apache.coyote.,\
+org.apache.jasper.,org.apache.naming.,org.apache.tomcat.
+
+#
+#
+# List of comma-separated paths defining the contents of the "common"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank,the JVM system loader will be used as Catalina's "common"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values are enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+common.loader="${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar"
+
+#
+# List of comma-separated paths defining the contents of the "server"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank, the "common" loader will be used as Catalina's "server"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+server.loader=
+
+#
+# List of comma-separated paths defining the contents of the "shared"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_BASE path or absolute. If left as blank,
+# the "common" loader will be used as Catalina's "shared" loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+# Please note that for single jars, e.g. bar.jar, you need the URL form
+# starting with file:.
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+shared.loader=
+
+# Default list of JAR files that should not be scanned using the JarScanner
+# functionality. This is typically used to scan JARs for configuration
+# information. JARs that do not contain such information may be excluded from
+# the scan to speed up the scanning process. This is the default list. JARs on
+# this list are excluded from all scans. The list must be a comma separated list
+# of JAR file names.
+# The list of JARs to skip may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+# The JARs listed below include:
+# - Tomcat Bootstrap JARs
+# - Tomcat API JARs
+# - Catalina JARs
+# - Jasper JARs
+# - Tomcat JARs
+# - Common non-Tomcat JARs
+# - Test JARs (JUnit, Cobertura and dependencies)
+# JAR files starting with HikariCP-*.jar are from fcrepo-webapp.war
+# that were being scanned for TLDs by default
+tomcat.util.scan.StandardJarScanFilter.jarsToSkip=\
+annotations-api.jar,\
+ant-junit*.jar,\
+ant-launcher.jar,\
+ant.jar,\
+asm-*.jar,\
+aspectj*.jar,\
+bootstrap.jar,\
+catalina-ant.jar,\
+catalina-ha.jar,\
+catalina-jmx-remote.jar,\
+catalina-storeconfig.jar,\
+catalina-tribes.jar,\
+catalina-ws.jar,\
+catalina.jar,\
+cglib-*.jar,\
+cobertura-*.jar,\
+commons-beanutils*.jar,\
+commons-codec*.jar,\
+commons-collections*.jar,\
+commons-daemon.jar,\
+commons-dbcp*.jar,\
+commons-digester*.jar,\
+commons-fileupload*.jar,\
+commons-httpclient*.jar,\
+commons-io*.jar,\
+commons-lang*.jar,\
+commons-logging*.jar,\
+commons-math*.jar,\
+commons-pool*.jar,\
+derby-*.jar,\
+dom4j-*.jar,\
+easymock-*.jar,\
+ecj-*.jar,\
+el-api.jar,\
+geronimo-spec-jaxrpc*.jar,\
+h2*.jar,\
+ha-api-*.jar,\
+hamcrest-*.jar,\
+hibernate*.jar,\
+httpclient*.jar,\
+icu4j-*.jar,\
+jasper-el.jar,\
+jasper.jar,\
+jaspic-api.jar,\
+jaxb-*.jar,\
+jaxen-*.jar,\
+jaxws-rt-*.jar,\
+jdom-*.jar,\
+jetty-*.jar,\
+jmx-tools.jar,\
+jmx.jar,\
+jsp-api.jar,\
+jstl.jar,\
+jta*.jar,\
+junit-*.jar,\
+junit.jar,\
+log4j*.jar,\
+mail*.jar,\
+objenesis-*.jar,\
+oraclepki.jar,\
+oro-*.jar,\
+servlet-api-*.jar,\
+servlet-api.jar,\
+slf4j*.jar,\
+taglibs-standard-spec-*.jar,\
+tagsoup-*.jar,\
+tomcat-api.jar,\
+tomcat-coyote.jar,\
+tomcat-dbcp.jar,\
+tomcat-i18n-*.jar,\
+tomcat-jdbc.jar,\
+tomcat-jni.jar,\
+tomcat-juli-adapters.jar,\
+tomcat-juli.jar,\
+tomcat-util-scan.jar,\
+tomcat-util.jar,\
+tomcat-websocket.jar,\
+tools.jar,\
+websocket-api.jar,\
+wsdl4j*.jar,\
+xercesImpl.jar,\
+xml-apis.jar,\
+xmlParserAPIs-*.jar,\
+xmlParserAPIs.jar,\
+xom-*.jar,\
+HikariCP-*.jar,\
+activemq-broker-*.jar,\
+activemq-client-*.jar,\
+activemq-jms-pool-*.jar,\
+activemq-kahadb-store-*.jar,\
+activemq-openwire-legacy-*.jar,\
+activemq-pool-*.jar,\
+activemq-protobuf-*.jar,\
+activemq-spring-*.jar,\
+activemq-stomp-*.jar,\
+aopalliance-*.jar,\
+aopalliance-repackaged-*.jar,\
+bcpkix-jdk15on-*.jar,\
+bcprov-jdk15on-*.jar,\
+bean-validator-*.jar,\
+caffeine-*.jar,\
+cas-client-core-*.jar,\
+class-model-*.jar,\
+collection-*.jar,\
+commons-chain-*.jar,\
+commons-cli-*.jar,\
+commons-csv-*.jar,\
+commons-net-*.jar,\
+commons-validator-*.jar,\
+config-types-*.jar,\
+fcrepo-auth-common-*.jar,\
+fcrepo-auth-roles-common-*.jar,\
+fcrepo-event-serialization-*.jar,\
+fcrepo-http-api-*.jar,\
+fcrepo-http-commons-*.jar,\
+fcrepo-jms-*.jar,\
+fcrepo-kernel-api-*.jar,\
+fcrepo-kernel-modeshape-*.jar,\
+fcrepo-metrics-*.jar,\
+fcrepo-module-auth-webac-*.jar,\
+geronimo-j2ee-management_*.jar,\
+geronimo-jms_*.jar,\
+geronimo-jta_*.jar,\
+guava-*.jar,\
+hawtbuf-*.jar,\
+hk2-*.jar,\
+hk2-api-*.jar,\
+hk2-config-*.jar,\
+hk2-core-*.jar,\
+hk2-locator-*.jar,\
+hk2-runlevel-*.jar,\
+hk2-utils-*.jar,\
+httpcore-*.jar,\
+jackson-annotations-*.jar,\
+jackson-core-*.jar,\
+jackson-databind-*.jar,\
+jackson-datatype-jsr310-*.jar,\
+jackson-jaxrs-base-*.jar,\
+jackson-jaxrs-json-provider-*.jar,\
+jackson-module-jaxb-annotations-*.jar,\
+javassist-*.jar,\
+javax.annotation-api-*.jar,\
+javax.inject-1.jar,\
+javax.inject-*.jar,\
+javax.servlet-api-*.jar,\
+javax.ws.rs-api-*.jar,\
+jboss-connector-api_*.jar,\
+jboss-transaction-api_*.jar,\
+jboss-transaction-spi-*.jar,\
+jcl-over-slf4j-*.jar,\
+jcr-*.jar,\
+jena-arq-*.jar,\
+jena-base-*.jar,\
+jena-core-*.jar,\
+jena-iri-*.jar,\
+jena-shaded-guava-*.jar,\
+jena-tdb-*.jar,\
+jersey-client-*.jar,\
+jersey-common-*.jar,\
+jersey-container-servlet-core-*.jar,\
+jersey-entity-filtering-*.jar,\
+jersey-guava-*.jar,\
+jersey-media-jaxb-*.jar,\
+jersey-media-json-jackson-*.jar,\
+jersey-media-multipart-*.jar,\
+jersey-server-*.jar,\
+jersey-spring3-*.jar,\
+jgroups-*.jar,\
+jjwt-api-*.jar,\
+jjwt-impl-*.jar,\
+jjwt-jackson-*.jar,\
+jsonld-java-*.jar,\
+ldaptive-*.jar,\
+libthrift-*.jar,\
+logback-classic-*.jar,\
+logback-core-*.jar,\
+mapdb-*.jar,\
+metrics-annotation-*.jar,\
+metrics-core-*.jar,\
+metrics-graphite-*.jar,\
+metrics-healthchecks-*.jar,\
+metrics-jersey2-*.jar,\
+metrics-json-*.jar,\
+metrics-jvm-*.jar,\
+metrics-servlets-*.jar,\
+mimepull-*.jar,\
+modeshape-common-*.jar,\
+modeshape-jcr-*.jar,\
+modeshape-jcr-api-*.jar,\
+modeshape-persistence-file-*.jar,\
+modeshape-persistence-relational-*.jar,\
+modeshape-schematic-*.jar,\
+modeshape-web-jcr-*.jar,\
+narayana-jta-*.jar,\
+osgi-resource-locator-*.jar,\
+postgresql-*.jar,\
+spring-aop-*.jar,\
+spring-beans-*.jar,\
+spring-bridge-*.jar,\
+spring-context-*.jar,\
+spring-core-*.jar,\
+spring-expression-*.jar,\
+spring-security-core-*.jar,\
+spring-security-web-*.jar,\
+spring-test-*.jar,\
+spring-web-*.jar,\
+sslext-*.jar,\
+tiger-types-*.jar,\
+tika-core-*.jar,\
+validation-api-*.jar,\
+velocity-*.jar,\
+velocity-tools-*.jar,\
+xbean-spring-*.jar,\
+xercesImpl-*.jar,\
+xml-apis-*.jar
+
+# Default list of JAR files that should be scanned that overrides the default
+# jarsToSkip list above. This is typically used to include a specific JAR that
+# has been excluded by a broad file name pattern in the jarsToSkip list.
+# The list of JARs to scan may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+tomcat.util.scan.StandardJarScanFilter.jarsToScan=\
+log4j-taglib*.jar,\
+log4j-web*.jar,\
+log4javascript*.jar,\
+slf4j-taglib*.jar
+
+# String cache configuration.
+tomcat.util.buf.StringCache.byte.enabled=true
+#tomcat.util.buf.StringCache.char.enabled=true
+#tomcat.util.buf.StringCache.trainThreshold=500000
+#tomcat.util.buf.StringCache.cacheSize=5000
+
+# This system property is deprecated. Use the relaxedPathChars relaxedQueryChars
+# attributes of the Connector instead. These attributes permit a wider range of
+# characters to be configured as valid.
+# Allow for changes to HTTP request validation
+# WARNING: Using this option may expose the server to CVE-2016-6816
+#tomcat.util.http.parser.HttpParser.requestTargetAllow=|

--- a/logging.properties
+++ b/logging.properties
@@ -13,61 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+handlers = java.util.logging.ConsoleHandler
 
-.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
-
-############################################################
-# Handler specific properties.
-# Describes specific configuration info for Handlers.
-############################################################
-
-1catalina.org.apache.juli.AsyncFileHandler.level = FINE
-1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
-1catalina.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
-2localhost.org.apache.juli.AsyncFileHandler.level = FINE
-2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
-2localhost.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
-3manager.org.apache.juli.AsyncFileHandler.level = FINE
-3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
-3manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
-4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
-4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
-4host-manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
+.handlers = java.util.logging.ConsoleHandler
 
 java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 java.util.logging.ConsoleHandler.encoding = UTF-8
-
-
-############################################################
-# Facility specific properties.
-# Provides extra control for each logger.
-############################################################
-
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
-
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
-
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+org.apache.juli.OneLineFormatter.timeFormat = yyyy-MM-dd'T'HH:mm:ss.SSS
 
 # For example, set the org.apache.catalina.util.LifecycleBase logger to log
 # each component that extends LifecycleBase changing state:
 #org.apache.catalina.util.LifecycleBase.level = FINE
 
-# To see debug messages in TldLocationsCache, uncomment the following line:
-org.apache.jasper.compiler.TldLocationsCache.level = FINE
-org.apache.jasper.servlet.TldScanner.level = FINE
+# To see debug messages in TldLocationsCache and TldScanner, uncomment the following lines:
+#org.apache.jasper.compiler.TldLocationsCache.level = FINE
+#org.apache.jasper.servlet.TldScanner.level = FINE
 
 # To see debug messages for HTTP/2 handling, uncomment the following line:
 #org.apache.coyote.http2.level = FINE

--- a/logging.properties
+++ b/logging.properties
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = FINE
+1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+1catalina.org.apache.juli.AsyncFileHandler.encoding = UTF-8
+
+2localhost.org.apache.juli.AsyncFileHandler.level = FINE
+2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
+2localhost.org.apache.juli.AsyncFileHandler.encoding = UTF-8
+
+3manager.org.apache.juli.AsyncFileHandler.level = FINE
+3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
+3manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
+
+4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
+4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
+4host-manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+java.util.logging.ConsoleHandler.encoding = UTF-8
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+
+# For example, set the org.apache.catalina.util.LifecycleBase logger to log
+# each component that extends LifecycleBase changing state:
+#org.apache.catalina.util.LifecycleBase.level = FINE
+
+# To see debug messages in TldLocationsCache, uncomment the following line:
+org.apache.jasper.compiler.TldLocationsCache.level = FINE
+org.apache.jasper.servlet.TldScanner.level = FINE
+
+# To see debug messages for HTTP/2 handling, uncomment the following line:
+#org.apache.coyote.http2.level = FINE
+
+# To see debug messages for WebSocket handling, uncomment the following line:
+#org.apache.tomcat.websocket.level = FINE

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 <configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%p %d{HH:mm:ss.SSS} \(%c{0}\) %m%n</pattern>
+      <pattern>%date{yyyy-MM-dd'T'HH:mm:ss.SSS} %level [%thread] %class.%method %message%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
- Exclude JAR files from TLD-scanning.
- Include a customized catalina.properties configuration file in the Docker image.
- Added logging.properties to the Docker image.
- Removed file-based loggers from Docker image.
- Aligned Tomcat and fcrepo log message formats.

https://issues.umd.edu/browse/LIBFCREPO-1143