### PR TITLE
LIBFCREPO-1180. Made the Tomcat connection timeout configurable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ FROM tomcat:8.5.83-jdk8-temurin-jammy
 ENV CONTEXT_PATH=""
 # default heap size is 2 GB
 ENV TOMCAT_HEAP=2048m
+# default connection timout is 120 seconds (120,000 ms)
+ENV CONNECTION_TIMEOUT=120000
 
 RUN mkdir -p /opt/umd-fcrepo-webapp
 COPY --from=compile /opt/umd-fcrepo-webapp/target/umd-fcrepo-webapp.war /opt/umd-fcrepo-webapp/

--- a/server.xml
+++ b/server.xml
@@ -67,7 +67,7 @@
          Define a non-SSL HTTP/1.1 Connector on port 8080
     -->
     <Connector port="8080" protocol="HTTP/1.1"
-               connectionTimeout="20000"
+               connectionTimeout="${connection.timeout}"
                redirectPort="8443" />
     <!-- A "Connector" using the shared thread pool-->
     <!--

--- a/setenv.sh
+++ b/setenv.sh
@@ -9,4 +9,5 @@ export CATALINA_OPTS="-XX:+UseConcMarkSweepGC \
   -Dfile.encoding=UTF-8 \
   -Dfcrepo.home=/var/umd-fcrepo-webapp \
   -Dfcrepo.activemq.directory=/var/activemq \
-  -Dfcrepo.context.path=${CONTEXT_PATH}"
+  -Dfcrepo.context.path=${CONTEXT_PATH} \
+  -Dconnection.timeout=${CONNECTION_TIMEOUT}"


### PR DESCRIPTION
- Set via system property "connection.timeout", which is read from the environment variable "CONNECTION_TIMEOUT".
- Use a default connection timeout of 120 seconds

https://issues.umd.edu/browse/LIBFCREPO-1180