### PR TITLE
LIBDEVOPS-242. Override ActiveMQ version to 5.15.16.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,13 @@
   <artifactId>umd-fcrepo-webapp</artifactId>
   <name>UMD Fedora Repository Deployable Web Application</name>
   <description>The Fedora web application</description>
-  <version>2.7.2</version>
+  <version>2.7.3-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <properties>
+    <!-- overriding ActiveMQ version; minimum version should be 5.15.16 -->
+    <!-- see https://umd-dit.atlassian.net/browse/LIBDEVOPS-242 -->
+    <activemq.version>5.15.16</activemq.version>
     <apache.commons.validator.version>1.7</apache.commons.validator.version>
     <fcrepo.version>4.7.5-umd-1.1</fcrepo.version>
     <logback.version>1.1.7</logback.version>
@@ -178,7 +181,45 @@
       <artifactId>jstl</artifactId>
       <version>1.2</version>
     </dependency>
-    
+
+    <!-- overriding ActiveMQ version; minimum version should be 5.15.16 -->
+    <!-- see https://umd-dit.atlassian.net/browse/LIBDEVOPS-242 -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-spring</artifactId>
+      <version>${activemq.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-kahadb-store</artifactId>
+      <version>${activemq.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-stomp</artifactId>
+      <version>${activemq.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- Test dependencies --> 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This is to address this vulnerability: https://activemq.apache.org/security-advisories.data/CVE-2023-46604

https://umd-dit.atlassian.net/browse/LIBDEVOPS-242