### PR TITLE
LIBFCREPO-1518. Removed "basic-auth.properties" file and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ service after deploying the stack:
 # in the umd-fcrepo-docker directory
 docker stack deploy -c umd-fcrepo.yml umd-fcrepo
 docker service rm umd-fcrepo_repository
-``` 
+```
 
 You must also provide environment variables for the LDAP bind password, Postgres
 database password, and JWT secret:
@@ -47,20 +47,12 @@ mvn cargo:run
 
 ### Configuration
 
-The [IpMapperFilter], which determines access rights to resources, uses the 
+The [IpMapperFilter], which determines access rights to resources, uses the
 [src/test/resources/test-ip-mapping.properties] file by default, which does not
 provide any access rights for the `localhost` user. This can be modified by
 adding the localhost address (`127.0.0.1/32`) to a category in the
 `test-ip-mapping.properties` file, or by specifying a different file in the
 [pom.xml](pom.xml) file.
-
-The [BasicAuthFilter], which processes `Authorization: Basic ...` HTTP headers
-(if present), is configured by [src/test/resources/basic-auth.properties]. The
-following users are configured:
-
-| Username | Password | Role        |
-|----------|----------|-------------|
-| loris    | loris    | fedoraAdmin |
 
 ### Environment Variables
 
@@ -74,7 +66,6 @@ properties, to run the application:
 | `FCREPO_BASE_URL`        | ✓                       | http://localhost:8080/                                                                       |
 | `IP_MAPPING_FILE`        | ✓                       | conf/test-ip-mapping.properties                                                              |
 | `IP_MAPPING_HEADER_NAME` | ✓                       | X-Auth-IP-Mapping                                                                            |
-| `CREDENTIALS_FILE`       | ✓                       | conf/basic-auth.properties                                                                   |
 | `JWT_SECRET`             |                         ||
 | `LDAP_URL`               | ✓                       | ldap://directory.umd.edu                                                                     |
 | `LDAP_BASE_DN`           | ✓                       | ou=people,dc=umd,dc=edu                                                                      |
@@ -106,9 +97,9 @@ is as simple as running:
 mvn docker:build
 ```
 
-The resulting image will be tagged as `docker.lib.umd.edu/fcrepo-webapp`, 
-plus a version string. If the `project.version` property defined in the POM 
-file is a SNAPSHOT, the version string will be "latest". Otherwise, it will 
+The resulting image will be tagged as `docker.lib.umd.edu/fcrepo-webapp`,
+plus a version string. If the `project.version` property defined in the POM
+file is a SNAPSHOT, the version string will be "latest". Otherwise, it will
 be the `project.version` property value from the POM file.
 
 [Docker plugin configuration](pom.xml#L285-L296)
@@ -125,6 +116,4 @@ See the [LICENSE](LICENSE.md) file for license rights and limitations (Apache 2.
 [umd-fcrepo-docker]: https://github.com/umd-lib/umd-fcrepo-docker
 [IpMapperFilter]: src/main/java/edu/umd/lib/fcrepo/IpMapperFilter.java
 [src/test/resources/test-ip-mapping.properties]: src/test/resources/test-ip-mapping.properties
-[BasicAuthFilter]: src/main/java/edu/umd/lib/fcrepo/BasicAuthFilter.java
-[src/test/resources/basic-auth.properties]: src/test/resources/basic-auth.properties
 [fabric8io docker-maven-plugin]: http://dmp.fabric8.io/

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,6 @@
               <LDAP_USER_GROUP>cn=Application_Roles:Libraries:FCREPO:FCREPO-User,ou=grouper,ou=group,dc=umd,dc=edu</LDAP_USER_GROUP>
               <IP_MAPPING_FILE>conf/test-ip-mapping.properties</IP_MAPPING_FILE>
               <IP_MAPPING_HEADER_NAME>X-Auth-IP-Mapping</IP_MAPPING_HEADER_NAME>
-              <CREDENTIALS_FILE>conf/basic-auth.properties</CREDENTIALS_FILE>
             </systemProperties>
           </container>
           <configuration>
@@ -286,11 +285,6 @@
               <configfile>
                 <!-- Include "test-ip-mapping.properties" for the IP Mapping Filter for use as default mapping file-->
                 <file>${project.basedir}/src/test/resources/test-ip-mapping.properties</file>
-                <todir>conf</todir>
-              </configfile>
-              <configfile>
-                <!-- BasicAuthFilter configuration file -->
-                <file>${project.basedir}/src/test/resources/basic-auth.properties</file>
                 <todir>conf</todir>
               </configfile>
             </configfiles>

--- a/src/main/java/edu/umd/lib/fcrepo/BasicAuthFilter.java
+++ b/src/main/java/edu/umd/lib/fcrepo/BasicAuthFilter.java
@@ -28,6 +28,11 @@ import java.util.Set;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
+// Note: This class was originally added to support authentication from the
+// Loris IIIF image server which is no longer used.
+//
+// The configuration that used this class was removed in LIBFCREPO-1518, so
+// this class may no longer be necessary.
 public class BasicAuthFilter implements Filter {
   private static final Logger logger = LoggerFactory.getLogger(BasicAuthFilter.class);
 

--- a/src/main/resources/spring/configuration.xml
+++ b/src/main/resources/spring/configuration.xml
@@ -129,9 +129,6 @@
       </bean>
     </property>
   </bean>
-  <bean name="basicAuthFilter" class="edu.umd.lib.fcrepo.BasicAuthFilter">
-    <property name="credentialsFile" value="${CREDENTIALS_FILE}"/>
-  </bean>
   <bean name="ipMapperFilter" class="edu.umd.lib.fcrepo.IpMapperFilter">
     <property name="headerName" value="${IP_MAPPING_HEADER_NAME}"/>
     <property name="mappingFile" value="${IP_MAPPING_FILE}"/>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -42,7 +42,7 @@
     <servlet-name>token-servlet</servlet-name>
     <servlet-class>edu.umd.lib.fcrepo.GenerateTokenServlet</servlet-class>
   </servlet>
-  
+
   <servlet-mapping>
     <servlet-name>jersey-servlet</servlet-name>
     <url-pattern>/rest/*</url-pattern>
@@ -143,19 +143,6 @@
   </filter-mapping>
 
   <filter>
-    <filter-name>HTTP Basic Auth Filter</filter-name>
-    <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
-    <init-param>
-      <param-name>targetBeanName</param-name>
-      <param-value>basicAuthFilter</param-value>
-    </init-param>
-  </filter>
-  <filter-mapping>
-    <filter-name>HTTP Basic Auth Filter</filter-name>
-    <url-pattern>/*</url-pattern>
-  </filter-mapping>
-
-  <filter>
     <filter-name>Fedora Roles Filter</filter-name>
     <filter-class>edu.umd.lib.fcrepo.FedoraRolesFilter</filter-class>
   </filter>
@@ -166,7 +153,7 @@
     <url-pattern>/rest/*</url-pattern>
     <url-pattern>/user/*</url-pattern>
   </filter-mapping>
-  
+
   <filter>
     <filter-name>Fedora IP Mapper Filter</filter-name>
     <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>

--- a/src/test/resources/basic-auth.properties
+++ b/src/test/resources/basic-auth.properties
@@ -1,1 +1,0 @@
-loris=loris,fedoraAdmin


### PR DESCRIPTION
The "basic-auth.properties" file was used to support the Loris IIIF image server that is no longer being used, and was removed from the "k8s-fcrepo" configuration.

Removing the Spring configuration that relies on the "basic-auth.properties" file and the "CREDENTIALS_FILE" so that the application will start in Kubernetes.

Left the "BasicAuthFilter" Java class (with an explanatory note) in case it is needed in the future.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1518