### PR TITLE
LIBFCREPO-1775. Streamlined authorization role checking.

### DIFF
--- a/docs/ServletFilters.puml
+++ b/docs/ServletFilters.puml
@@ -1,0 +1,36 @@
+@startuml
+skinparam defaultTextAlignment center
+title umd-fcrepo-webapp Servlet Filter Chain
+
+start
+:<b>reverse-proxy-filter
+edu.umd.lib.fcrepo.ReverseProxyFilter;
+:<b>CAS Single Sign Out Filter
+org.jasig.cas.client.session.SingleSignOutFilter;
+if (request URI matches /user/*) then (yes)
+  :<b>CAS Authentication Filter
+  org.springframework.web.filter.DelegatingFilterProxy
+
+  targetBeanName=casAuthenticationFilter;
+else (no)
+endif
+:<b>CAS Validation Filter
+org.springframework.web.filter.DelegatingFilterProxy
+
+targetBeanName=casValidationFilter;
+:<b>CAS HttpServletRequest Wrapper Filter
+org.jasig.cas.client.util.HttpServletRequestWrapperFilter;
+:<b>JWT Bearer Token AuthNZ Filter
+edu.umd.lib.fcrepo.TokenAuthnzFilter;
+if (request URI matches /rest/* or /user/*) then (yes)
+  :<b>Fedora Roles Filter
+  edu.umd.lib.fcrepo.FedoraRolesFilter;
+  :<b>Fedora IP Mapper Filter
+  org.springframework.web.filter.DelegatingFilterProxy
+
+  targetBeanName=ipMapperFilter;
+else (no)
+endif
+stop
+
+@enduml

--- a/src/main/java/edu/umd/lib/fcrepo/FedoraRolesFilter.java
+++ b/src/main/java/edu/umd/lib/fcrepo/FedoraRolesFilter.java
@@ -12,25 +12,16 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import org.jasig.cas.client.authentication.AttributePrincipal;
-import org.ldaptive.ConnectionFactory;
-import org.ldaptive.SearchExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
 public class FedoraRolesFilter implements Filter {
+  public static final String SESSION_ROLE_KEY = "fedoraUserRole";
+
+  public static final String ADMIN_ROLE = "fedoraAdmin";
+
   private static final Logger logger = LoggerFactory.getLogger(FedoraRolesFilter.class);
-
-  private ConnectionFactory cf;
-
-  private String memberAttribute;
-
-  private String adminGroup;
-
-  private String userGroup;
-
-  private SearchExecutor searchExecutor;
 
   private LdapRoleLookupService ldapRoleLookupService;
 
@@ -83,24 +74,24 @@ public class FedoraRolesFilter implements Filter {
   /**
    * Returns the role for the user, or null if the role cannot be found.
    * 
-   * Implementation: This method first checks the HttpRequest session for the
+   * <p>Implementation: This method first checks the HttpRequest session for the
    * role. If a role is not found in the session, it performs an LDAP search
    * using the given userName. If a role is found, it is stored in the
-   * session and returned.
+   * session and returned.</p>
    * 
    * @param httpRequest the current HttpRequest object
    * @param userName the login id of the user
    * @return a role name string: "fedoraAdmin", "fedoraUser", or null
    */
   private String getRole(final HttpServletRequest httpRequest, final String userName) {
-    final String SESSION_ROLE_KEY = "fedoraUserRole";
-    
     // Attempt to retrieve role from session
     final HttpSession session = httpRequest.getSession(false);
     if ((session != null) && (session.getAttribute(SESSION_ROLE_KEY) != null)) {
        final String role = session.getAttribute(SESSION_ROLE_KEY).toString();
        logger.debug("User {} has role {} from session", userName, role);
        return role;
+    } else {
+        logger.debug("No role found in session");
     }
     
     // Retrieve role from LDAP 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -31,7 +31,7 @@
   <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="edu.umd.lib" additivity="false" level="INFO">
+  <logger name="edu.umd.lib" additivity="false" level="${fcrepo.umd.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/src/main/resources/spring/configuration.xml
+++ b/src/main/resources/spring/configuration.xml
@@ -118,19 +118,20 @@
   </bean>
 
   <bean name="ldapPoolConfig" class="org.ldaptive.pool.PoolConfig">
-    <property name="validateOnCheckOut" value="true" />
+    <property name="validatePeriodically" value="true" />
   </bean>
 
   <bean name="ldapSearchValidator" class="org.ldaptive.pool.SearchValidator">
     <property name="searchRequest">
       <bean class="org.ldaptive.SearchRequest">
         <property name="baseDn" value="${LDAP_BASE_DN}"/>
-        <property name="searchFilter" value="(cn=*)"/>
+        <property name="searchFilter" value="(${LDAP_BASE_DN})"/>
+        <property name="sizeLimit" value="1"/>
       </bean>
     </property>
   </bean>
 
-  <bean name="ldapConnectionPool" class="org.ldaptive.pool.SoftLimitConnectionPool">
+  <bean name="ldapConnectionPool" class="org.ldaptive.pool.BlockingConnectionPool">
     <constructor-arg ref="ldapConnectionFactory"/>
     <constructor-arg ref="ldapPoolConfig"/>
     <property name="validator" ref="ldapSearchValidator"/>


### PR DESCRIPTION
* Changed the LDAP connection validation strategy to periodic
* Changed the connection pool type to the blocking type
* Narrowed the validation search request
* Updated the TokenAuthnzFilter to add a non-null role extracted from the token payload to the HTTP request session, so that the downstream FedoraRolesFilter will be able to pick it up without having to query LDAP
* Added additional logging
* Other code and javadoc cleanup
* Added a `fcrepo.umd.log` property to control the log level of `edu.umd.lib.*` packages
* Added a servlet filter chain diagram

https://umd-dit.atlassian.net/browse/LIBFCREPO-1775